### PR TITLE
Docs: instrument metadata documentation

### DIFF
--- a/docs/source/acquire_upload/prepare_before_acquisition.md
+++ b/docs/source/acquire_upload/prepare_before_acquisition.md
@@ -204,7 +204,7 @@ The investigators endpoint will be used during data upload to populate your data
 
 ### ID
 
-The `instrument_id` for AIND should be the SIPE ID for a rig. If an instrument is not tracked by SIPE, any string will be accepted.
+The `instrument_id` for AIND should be the SIPE ID for an instrument. If an instrument is not tracked by SIPE, any string will be accepted.
 
 ### Other details
 


### PR DESCRIPTION
This PR adds documentation describing how to create, edit, save and fetch instrument metadata files. 

There's also a brief section on responsibility, making it clear that the ultimate responsibility for the instrument metadata being correct lies with the scientist, but that engineers should take responsibility when creating/modifying instruments.

Closes #9 

TO DO BEFORE MERGING:

- [x] Replace placeholder link for section on merging JSON files with valid link.
- [x] Clarify that instrument database storage only works for 2.0 schema instruments (since validation occurs). @arielleleon asked about this in a DM.
- [x] Add info to the save_instrument section clarifying that `replace=True` must be passed if posting more than once per day