### PR TITLE
Added language clarifying acq/inst sync responsibility

### DIFF
--- a/docs/source/acquire_upload/acquire_data.md
+++ b/docs/source/acquire_upload/acquire_data.md
@@ -20,7 +20,7 @@ See [aind-file-standards](https://github.com/allenneuralDynamics/aind-file-stand
 
 Rigs are responsible for generating the [acquisition.json](https://aind-data-schema.readthedocs.io/en/latest/acquisition.html) as well as any optional files (e.g., quality_control.json), if your situation requires it. You can either generate these metadata files directly or use the extractor/mapper pattern to extract necessary metadata on the rig and then map it in the cloud to aind-data-schema.
 
-References to the instrument in the `acquisition.json` must be consistent with the corresponding information in the [`instrument.json`](https://aind-data-schema.readthedocs.io/en/latest/instrument.html) (e.g., `instrument_id` must match, `active_devices` in each `DataStream` must be listed as devices in the corresponding `instrument.json`). Scientists collecting data should work closely with engineers maintaining their systems to ensure that this metadata remains consistent and will validate.
+References to the instrument in the `acquisition.json` must be consistent with the corresponding information in the [`instrument.json`](https://aind-data-schema.readthedocs.io/en/latest/instrument.html). See the [Instrument and Acquisition section in the AIND Data Schema docs](https://aind-data-schema.readthedocs.io/en/latest/validation.html) for details. Scientists collecting data should work closely with engineers maintaining their systems to ensure that this metadata remains consistent and will validate.
 
 #### Extractor / Mapper Pattern
 


### PR DESCRIPTION
Adds language emphasizing need to keep info in acquisition.json in sync with corresponding instrument.json.

Closes https://github.com/AllenNeuralDynamics/aind-software-docs/issues/48