### PR TITLE
Fix index.md for new outreach page under explore_analyze

### DIFF
--- a/docs/source/explore_analyze/index.md
+++ b/docs/source/explore_analyze/index.md
@@ -16,7 +16,7 @@ orphan: true
 
 [Explore custom tools](analyze_data.md#custom-tools) for annotation and data exploration.
 
-[Find workshops](workshops.md).
+[Find outreach](outreach.md).
 
 ```{toctree}
 :hidden:
@@ -24,5 +24,5 @@ orphan: true
 quality_control
 find_data
 analyze_data
-workshops
+outreach
 ```

--- a/docs/source/explore_analyze/index.md
+++ b/docs/source/explore_analyze/index.md
@@ -16,7 +16,7 @@ orphan: true
 
 [Explore custom tools](analyze_data.md#custom-tools) for annotation and data exploration.
 
-[Find outreach](outreach.md).
+[Find outreach events](outreach.md).
 
 ```{toctree}
 :hidden:


### PR DESCRIPTION
 I renamed workshop.md to outreach.md in a previous PR and didn't update the index.md under explore_analyze. Updated the index so that the page will show up. 