### PR TITLE
Added job type override info to upload_data.md

### DIFF
--- a/docs/source/acquire_upload/upload_data.md
+++ b/docs/source/acquire_upload/upload_data.md
@@ -8,6 +8,25 @@ In general, most users should interact with the transfer service by requesting d
 
 For example, this [upload script](https://github.com/AllenNeuralDynamics/aind-data-transfer-service/blob/d1f84020862c3de340020b6cb45bef0fd5105515/docs/examples/aind_data_schema_v2.py) demonstrates how to setup the upload parameters for a standard ecephys data asset using the `"default"` job_type. You can view [all available job_type options](https://aind-data-transfer-service.corp.alleninstitute.org/job_params). Please reach out to the Data & Infrastructure team in Scientific Computing to develop custom job types for your data assets.
 
+Job types define convenient defaults, but you are not locked into them — **any parameter set by the job type can be overridden in your upload script**. For example, to pin the metadata mapper to a specific version rather than using the job type's default:
+
+```python
+from aind_data_transfer_service.models.core import Task, UploadJobConfigsV2
+
+gather_preliminary_metadata = Task(
+    image_version="v1.1.0",  # overrides the job_type default
+    job_settings={"metadata_dir": "/path/to/your/data"},
+)
+
+upload_job_configs = UploadJobConfigsV2(
+    job_type="vr_foraging_fiber",  # all other defaults still come from the job_type
+    ...
+    tasks={"gather_preliminary_metadata": gather_preliminary_metadata},
+)
+```
+
+Available mapper versions are listed [here](https://github.com/AllenNeuralDynamics/aind-metadata-mapper/pkgs/container/aind-metadata-mapper). For a complete reference of all parameters you can control, see [this example script](https://github.com/AllenNeuralDynamics/aind-data-transfer-service/blob/dev/docs/examples/aind_data_schema_v2.py).
+
 ## GatherMetadataJob
 
 The [GatherMetadataJob](https://github.com/AllenNeuralDynamics/aind-metadata-mapper/tree/release-v1.0.0#usage) is the primary tool used to assemble and validate metadata during upload of data assets. The job handles construction of the `data_description`, `subject`, and `procedures` as well as merging and validating `instrument` and `acquisition` metadata. It also runs a full validation step on all available metadata files to ensure cross-compatibility.


### PR DESCRIPTION
Adds to `upload_data.md` to help make it clearer to users that they have the ability to override any default args in a given pre-defined data transfer service job_type. Includes a bare-bones code snippet, then a link to a full example (which already existed).