### PR TITLE
Add publication standards link generator

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,3 +71,6 @@ html_show_sphinx = False
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 html_show_copyright = False
+
+# make the raw markdown file available in the output directory so it can be linked to
+html_extra_path = ["policies_practices/standards_checklist.md"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ myst_enable_extensions = [
     "deflist",
     "fieldlist",
     "tasklist",
+    "attrs_block",
 ]
 myst_heading_anchors = 3
 

--- a/docs/source/glossary.md
+++ b/docs/source/glossary.md
@@ -1,0 +1,5 @@
+# Glossary
+
+{.glossary}
+intermediate result
+: derived data that consists of an analysis result saved as input for downstream analysis steps.

--- a/docs/source/policies_practices/publication_standards.md
+++ b/docs/source/policies_practices/publication_standards.md
@@ -32,6 +32,60 @@ This checklist is intended to make the code publication standards set out in the
 
 [^*]: This is a temporary solution that we hope to simplify/automate as part of the capsule release process.
 
+### Use this checklist on github
+This form will let you open an issue on your capsule's repo with the checklist pre-filled, if you want to track tasks or coordinate with a reviewer using github.
+
+<p>
+<input type="text" id="userInput" placeholder="Github repository url">
+<!-- Button to trigger the link generation -->
+<button onclick="generateLink()">Generate Link</button>
+<a id="resultLink" href="#" target="_blank"></a>
+</p>
+
+<script>
+function generateLink() {
+    // Get the value from the input field
+    const value = document.getElementById('userInput').value;
+    const linkElement = document.getElementById('resultLink');
+
+    const checklist = `
+### Capsules and repositories
+- [ ] Capsules (or pipelines) for all processing steps, from raw data to figures [^tools]
+[^tools]: Tools that already have, or are progressing towards, a separate public release may be left out.
+- [ ] Working copy of capsule shared internally and linked to a public github repository within AIND or AIBS github organization
+- [ ] Released version of capsule added to manuscript collection (requires author and description in capsule metadata, sync to github, and reproducible run).
+- [ ] Reproducible run script generates all outputs[^nb] (if manual steps are unavoidable, include step-by-step instructions and automate as much as possible).
+[^nb]: This can trigger execution of notebooks (e.g. using nbconvert), as long as they run top to bottom with no interaction required.
+- [ ] Figure outputs saved to results folder, with filenames indicating the corresponding figure number (and subpanel letter if possible).
+- [ ] Code consolidated in code folder, with unused code removed or clearly documented.
+- [ ] Explicitly specified (pinned) versions for all direct imports and other critical dependencies[^env]
+[^env]: Versions must be recorded in the Environment Builder, dockerfile, or other files linked during docker build (postinstall, requirements.txt etc)
+
+### Data
+- [ ] All AIND data stored as external data assets (aind-open-data), with complete metadata 
+- [ ] All *intermediate results* stored as external data assets (aind-open-data), with processing metadata added.
+- [ ] All data from external sources documented and downloadable with clear instructions from a stable data repository, or mirrored in aind-open-data.
+- [ ] If many individual assets are used, create combined data assets to organize them by data modality or type
+- [ ] All data assets (combined if needed) added to public collection -- *intermediate results* should be included on a case-by-case basis.
+
+### Readme and other docs
+- [ ] Includes links to manuscript, github repo, and release capsule (add the latter before making a second release).[^*]
+- [ ] Briefly describes all experimental data types and other inputs.
+- [ ] Briefly describes all non-figure outputs (intermediate results).
+- [ ] Briefly explains key analysis steps (reference relevant code by file or function names).
+- [ ] LICENSE file at top level of repo (MIT license).`;
+
+    // Check if value is empty
+    if (value) {
+        // Create the full URL (example using Google search)
+        const fullUrl = value + "/issues/new?title=Publication-standards&body=" + encodeURIComponent(checklist);
+        
+        // Update the link's href and display text
+        linkElement.href = fullUrl;
+        linkElement.innerText = "Open github issue";
+    }
+}
+</script>
 
 ## Code review
 

--- a/docs/source/policies_practices/publication_standards.md
+++ b/docs/source/policies_practices/publication_standards.md
@@ -17,92 +17,35 @@ This link generator will let you open an issue on your capsule's github reposito
 </p>
 
 <script>
-function generateLink() {
-    // Get the value from the input field
+async function generateLink() {
     const value = document.getElementById('userInput').value;
+    if (!value) return;
+
     const linkElement = document.getElementById('resultLink');
+    const response = await fetch('../standards_checklist.md');
+    const checklist = await response.text();
 
-    const checklist = `
-### Capsules and repositories
-- [ ] Capsules (or pipelines) for all processing steps, from raw data to figures [^tools]
-[^tools]: Tools that already have, or are progressing towards, a separate public release may be left out.
-- [ ] Working copy of capsule shared internally and linked to a public github repository within AIND or AIBS github organization
-- [ ] Released version of capsule added to manuscript collection (requires author and description in capsule metadata, sync to github, and reproducible run).
-- [ ] Reproducible run script generates all outputs[^nb] (if manual steps are unavoidable, include step-by-step instructions and automate as much as possible).
-[^nb]: This can trigger execution of notebooks (e.g. using nbconvert), as long as they run top to bottom with no interaction required.
-- [ ] Figure outputs saved to results folder, with filenames indicating the corresponding figure number (and subpanel letter if possible).
-- [ ] Code consolidated in code folder, with unused code removed or clearly documented.
-- [ ] Explicitly specified (pinned) versions for all direct imports and other critical dependencies[^env]
-[^env]: Versions must be recorded in the Environment Builder, dockerfile, or other files linked during docker build (postinstall, requirements.txt etc)
-
-### Data
-- [ ] All AIND data stored as external data assets (aind-open-data), with complete metadata 
-- [ ] All *intermediate results* stored as external data assets (aind-open-data), with processing metadata added.
-- [ ] All data from external sources documented and downloadable with clear instructions from a stable data repository, or mirrored in aind-open-data.
-- [ ] If many individual assets are used, create combined data assets to organize them by data modality or type
-- [ ] All data assets (combined if needed) added to public collection -- *intermediate results* should be included on a case-by-case basis.
-
-### Readme and other docs
-- [ ] Includes links to manuscript, github repo, and release capsule (add the latter before making a second release).[^*]
-- [ ] Briefly describes all experimental data types and other inputs.
-- [ ] Briefly describes all non-figure outputs (intermediate results).
-- [ ] Briefly explains key analysis steps (reference relevant code by file or function names).
-- [ ] LICENSE file at top level of repo (MIT license).`;
-
-    // Check if value is empty
-    if (value) {
-        // Create the full URL (example using Google search)
-        const fullUrl = value + "/issues/new?title=Publication-standards&body=" + encodeURIComponent(checklist);
-        
-        // Update the link's href and display text
-        linkElement.href = fullUrl;
-        linkElement.innerText = "Open github issue";
-    }
+    const fullUrl = value + "/issues/new?title=Publication-standards&body=" + encodeURIComponent(checklist);
+    linkElement.href = fullUrl;
+    linkElement.innerText = "Open github issue";
 }
 </script>
 
 ```
 
-### Capsules and repositories
-- [ ] Capsules (or pipelines) for all processing steps, from raw data to figures [^tools]
-[^tools]: Tools that already have, or are progressing towards, a separate public release may be left out.
-- [ ] Working copy of capsule shared internally and linked to a public github repository within AIND or AIBS github organization
-- [ ] Released version of capsule added to manuscript collection (requires author and description in capsule metadata, sync to github, and reproducible run).
-- [ ] Reproducible run script generates all outputs[^nb] (if manual steps are unavoidable, include step-by-step instructions and automate as much as possible).
-[^nb]: This can trigger execution of notebooks (e.g. using nbconvert), as long as they run top to bottom with no interaction required.
-- [ ] Figure outputs saved to `results` folder, with filenames indicating the corresponding figure number (and subpanel letter if possible).
-- [ ] Code consolidated in `code` folder, with unused code removed or clearly documented.
-- [ ] Explicitly specified (pinned) versions for all direct imports and other critical dependencies[^env]
-[^env]: Versions must be recorded in the Environment Builder, dockerfile, or other files linked during docker build (postinstall, requirements.txt etc)
-
-### Data
-- [ ] All AIND data stored as external data assets (aind-open-data), with complete metadata 
-- [ ] All {term}`intermediate result`s stored as external data assets (aind-open-data), with processing metadata added.
-- [ ] All data from external sources documented and downloadable with clear instructions from a stable data repository, or mirrored in aind-open-data.
-- [ ] If many individual assets are used, create combined data assets to organize them by data modality or type
-- [ ] All data assets (combined if needed) added to public collection -- *intermediate results* should be included on a case-by-case basis.
-
-### Readme and other docs
-- [ ] Includes links to manuscript, github repo, and release capsule (add the latter before making a second release).[^*]
-- [ ] Briefly describes all experimental data types and other inputs.
-- [ ] Briefly describes all non-figure outputs (intermediate results).
-- [ ] Briefly explains key analysis steps (reference relevant code by file or function names).
-- [ ] LICENSE file at top level of repo (MIT license).
-
-[^*]: This is a temporary solution that we hope to simplify/automate as part of the capsule release process.
+```{include} standards_checklist.md
+```
 
 ## Code review process
 
 - Reviewer will adopt the perspective of an external user, and check that code meets these standards and is reproducible and reusable (able to identify and adjust key parameters, not necessarily understand each line).
 - Reviewer must be a scientist who has not contributed to the capsule, but may be a manuscript author or someone otherwise knowledgeable about the general approach. A SciComp team member may be looped in for advise and oversight as necessary.
 - Required edits will typically consist of moving/renaming, documenting, commenting, and otherwise making code intelligible without much refactoring.
-- Review must be completed and issues addressed before biorxiv or other publicity.[^exc]
-    
-[^exc]: There may be exceptions to this as we adjust to the process, especially if infrastructure or other challenges prevent fulfilling the standards before a biorxiv release. The Capsule and Repositories requirements are a bare minimum, and all requirements must be met by final publication.
+- Review must be completed and issues addressed before biorxiv or other publicity.[^6]
+[^6]: There may be exceptions to this as we adjust to the process, especially if infrastructure or other challenges prevent fulfilling the standards before a biorxiv release. The Capsule and Repositories requirements are a bare minimum, and all requirements must be met by final publication.
 
-- Reviewer should also offer suggestions for refactoring to match best practices in this document and resolve code style issues (using flake8 as a guide).[^rev]
-    
-[^rev]: We are currently working on developing a clearer process for code review, including a selection of automated linter rules for reviewers to check.
+- Reviewer should also offer suggestions for refactoring to match best practices in this document and resolve code style issues (using flake8 as a guide).[^7]
+[^7]: We are currently working on developing a clearer process for code review, including a selection of automated linter rules for reviewers to check.
 
 
 ## Additional best practices

--- a/docs/source/policies_practices/publication_standards.md
+++ b/docs/source/policies_practices/publication_standards.md
@@ -1,39 +1,13 @@
 # Publication standards for Code Ocean
 
-This checklist is intended to make the code publication standards set out in the Open Science Policy document clearer and more usable in the context of code hosted on Code Ocean. The review process documents how we will help each other meet these standards. The best practices below go beyond the minimum standards to further promote reuse and reproducibility, and should be preferred when possible.
+This <project:#standards-checklist> is intended to make the code publication standards set out in the Open Science Policy document clearer and more usable in the context of code hosted on Code Ocean. The <project:#code-review-process> documents how we will help each other meet these standards. The <project:#additional-best-practices> below go beyond the minimum standards to further promote reuse and reproducibility, and should be preferred when possible.
 
 ## Standards checklist
 
-### Capsules and repositories
-- [ ] Capsules (or pipelines) for all processing steps, from raw data to figures [^tools]
-[^tools]: Tools that already have, or are progressing towards, a separate public release may be left out.
-- [ ] Working copy of capsule shared internally and linked to a public github repository within AIND or AIBS github organization
-- [ ] Released version of capsule added to manuscript collection (requires author and description in capsule metadata, sync to github, and reproducible run).
-- [ ] Reproducible run script generates all outputs[^nb] (if manual steps are unavoidable, include step-by-step instructions and automate as much as possible).
-[^nb]: This can trigger execution of notebooks (e.g. using nbconvert), as long as they run top to bottom with no interaction required.
-- [ ] Figure outputs saved to `results` folder, with filenames indicating the corresponding figure number (and subpanel letter if possible).
-- [ ] Code consolidated in `code` folder, with unused code removed or clearly documented.
-- [ ] Explicitly specified (pinned) versions for all direct imports and other critical dependencies[^env]
-[^env]: Versions must be recorded in the Environment Builder, dockerfile, or other files linked during docker build (postinstall, requirements.txt etc)
+```{admonition} Use this checklist on github
+:class: hint
 
-### Data
-- [ ] All AIND data stored as external data assets (aind-open-data), with complete metadata 
-- [ ] All *intermediate results* stored as external data assets (aind-open-data), with processing metadata added.
-- [ ] All data from external sources documented and downloadable with clear instructions from a stable data repository, or mirrored in aind-open-data.
-- [ ] If many individual assets are used, create combined data assets to organize them by data modality or type
-- [ ] All data assets (combined if needed) added to public collection -- *intermediate results* should be included on a case-by-case basis.
-
-### Readme and other docs
-- [ ] Includes links to manuscript, github repo, and release capsule (add the latter before making a second release).[^*]
-- [ ] Briefly describes all experimental data types and other inputs.
-- [ ] Briefly describes all non-figure outputs (intermediate results).
-- [ ] Briefly explains key analysis steps (reference relevant code by file or function names).
-- [ ] LICENSE file at top level of repo (MIT license).
-
-[^*]: This is a temporary solution that we hope to simplify/automate as part of the capsule release process.
-
-### Use this checklist on github
-This form will let you open an issue on your capsule's repo with the checklist pre-filled, if you want to track tasks or coordinate with a reviewer using github.
+This link generator will let you open an issue on your capsule's github repository with the checklist pre-filled. You can use this to track tasks or coordinate with a reviewer.
 
 <p>
 <input type="text" id="userInput" placeholder="Github repository url">
@@ -87,7 +61,37 @@ function generateLink() {
 }
 </script>
 
-## Code review
+```
+
+### Capsules and repositories
+- [ ] Capsules (or pipelines) for all processing steps, from raw data to figures [^tools]
+[^tools]: Tools that already have, or are progressing towards, a separate public release may be left out.
+- [ ] Working copy of capsule shared internally and linked to a public github repository within AIND or AIBS github organization
+- [ ] Released version of capsule added to manuscript collection (requires author and description in capsule metadata, sync to github, and reproducible run).
+- [ ] Reproducible run script generates all outputs[^nb] (if manual steps are unavoidable, include step-by-step instructions and automate as much as possible).
+[^nb]: This can trigger execution of notebooks (e.g. using nbconvert), as long as they run top to bottom with no interaction required.
+- [ ] Figure outputs saved to `results` folder, with filenames indicating the corresponding figure number (and subpanel letter if possible).
+- [ ] Code consolidated in `code` folder, with unused code removed or clearly documented.
+- [ ] Explicitly specified (pinned) versions for all direct imports and other critical dependencies[^env]
+[^env]: Versions must be recorded in the Environment Builder, dockerfile, or other files linked during docker build (postinstall, requirements.txt etc)
+
+### Data
+- [ ] All AIND data stored as external data assets (aind-open-data), with complete metadata 
+- [ ] All {term}`intermediate result`s stored as external data assets (aind-open-data), with processing metadata added.
+- [ ] All data from external sources documented and downloadable with clear instructions from a stable data repository, or mirrored in aind-open-data.
+- [ ] If many individual assets are used, create combined data assets to organize them by data modality or type
+- [ ] All data assets (combined if needed) added to public collection -- *intermediate results* should be included on a case-by-case basis.
+
+### Readme and other docs
+- [ ] Includes links to manuscript, github repo, and release capsule (add the latter before making a second release).[^*]
+- [ ] Briefly describes all experimental data types and other inputs.
+- [ ] Briefly describes all non-figure outputs (intermediate results).
+- [ ] Briefly explains key analysis steps (reference relevant code by file or function names).
+- [ ] LICENSE file at top level of repo (MIT license).
+
+[^*]: This is a temporary solution that we hope to simplify/automate as part of the capsule release process.
+
+## Code review process
 
 - Reviewer will adopt the perspective of an external user, and check that code meets these standards and is reproducible and reusable (able to identify and adjust key parameters, not necessarily understand each line).
 - Reviewer must be a scientist who has not contributed to the capsule, but may be a manuscript author or someone otherwise knowledgeable about the general approach. A SciComp team member may be looped in for advise and oversight as necessary.

--- a/docs/source/policies_practices/standards_checklist.md
+++ b/docs/source/policies_practices/standards_checklist.md
@@ -1,0 +1,27 @@
+### Capsules and repositories
+- [ ] Capsules (or pipelines) for all processing steps, from raw data to figures [^3]
+[^3]: Tools that already have, or are progressing towards, a separate public release may be left out.
+- [ ] Working copy of capsule shared internally and linked to a public github repository within AIND or AIBS github organization
+- [ ] Released version of capsule added to manuscript collection (requires author and description in capsule metadata, sync to github, and reproducible run).
+- [ ] Reproducible run script generates all outputs[^4] (if manual steps are unavoidable, include step-by-step instructions and automate as much as possible).
+[^4]: This can trigger execution of notebooks (e.g. using nbconvert), as long as they run top to bottom with no interaction required.
+- [ ] Figure outputs saved to `results` folder, with filenames indicating the corresponding figure number (and subpanel letter if possible).
+- [ ] Code consolidated in `code` folder, with unused code removed or clearly documented.
+- [ ] Explicitly specified (pinned) versions for all direct imports and other critical dependencies[^5]
+[^5]: Versions must be recorded in the Environment Builder, dockerfile, or other files linked during docker build (postinstall, requirements.txt etc)
+
+### Data
+- [ ] All AIND data stored as external data assets (aind-open-data), with complete metadata 
+- [ ] All {term}`intermediate result`s stored as external data assets (aind-open-data), with processing metadata added.
+- [ ] All data from external sources documented and downloadable with clear instructions from a stable data repository, or mirrored in aind-open-data.
+- [ ] If many individual assets are used, create combined data assets to organize them by data modality or type
+- [ ] All data assets (combined if needed) added to public collection -- *intermediate results* should be included on a case-by-case basis.
+
+### Readme and other docs
+- [ ] Includes links to manuscript, github repo, and release capsule (add the latter before making a second release).[^*]
+- [ ] Briefly describes all experimental data types and other inputs.
+- [ ] Briefly describes all non-figure outputs (intermediate results).
+- [ ] Briefly explains key analysis steps (reference relevant code by file or function names).
+- [ ] LICENSE file at top level of repo (MIT license).
+
+[^*]: This is a temporary solution that we hope to simplify/automate as part of the capsule release process.


### PR DESCRIPTION
Embeds some html/javascript in the publication standards page where the user enters their github repo url, and it provides a link to open an issue with the standards checklist pre-filled.

(this requires duplicating the checklist markdown as a js string literal, hopefully i can figure out a way to avoid that later).