### PR TITLE
feat: enable tippy hover previews

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,11 +32,19 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "sphinx_tippy",
     "myst_parser",
 ]
 templates_path = ["_templates"]
 exclude_patterns = []
 jupyter_execute_notebooks = "off"
+
+# tippy
+tippy_enable_wikitips = False
+# Skip all except those starting with "#id" (footnote) or "../glossary"
+tippy_skip_urls = [
+    "^(?!#id|../glossary|glossary).*$",
+]
 
 # -- MyST configuration ------------------------------------------------------
 myst_enable_extensions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,10 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    'black',
-    'coverage',
-    'flake8',
-    'interrogate',
-    'isort',
     'Sphinx',
     'furo',
     'myst-parser',
+    'sphinx-tippy',
 ]
 
 [tool.setuptools.packages.find]
@@ -37,44 +33,3 @@ where = ["src"]
 [tool.setuptools.dynamic]
 version = {attr = "aind_software_docs.__version__"}
 
-[tool.black]
-line-length = 79
-target_version = ['py310']
-exclude = '''
-
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | build
-    | dist
-  )/
-  | .gitignore
-)
-'''
-
-[tool.coverage.run]
-omit = ["*__init__*"]
-source = ["aind_software_docs", "tests"]
-
-[tool.coverage.report]
-exclude_lines = [
-    "if __name__ == .__main__.:",
-    "from",
-    "import",
-    "pragma: no cover"
-]
-fail_under = 100
-
-[tool.isort]
-line_length = 79
-profile = "black"
-
-[tool.interrogate]
-exclude = ["setup.py", "docs", "build"]
-fail-under = 100


### PR DESCRIPTION
this adds the spinx-tippy package / sphinx extension, to generate preview tooltips when users mouseover certain types of link. 
I used the tippy_skip_urls regex to allow this only on links to footnotes or glossary terms for now, since the rest are fairly distracting.

<!-- readthedocs-preview scicomp-docs start -->
----
📚 Documentation preview 📚: https://scicomp-docs--124.org.readthedocs.build/en/124/

<!-- readthedocs-preview scicomp-docs end -->