### PR TITLE
Update Dynamic Foraging repo link

### DIFF
--- a/docs/source/acquire_upload/process_data.md
+++ b/docs/source/acquire_upload/process_data.md
@@ -38,4 +38,4 @@ Pipeline development requirements are documented in [Pipeline development](../po
 
 | Project name | Modalities | Pipeline repository |
 |---|---|---|
-| Dynamic foraging | `behavior`, `behavior-videos`, `fib` | [aind-dynamic-foraging-pipeline](https://github.com/AllenNeuralDynamics/aind-dynamic-foraging-pipeline) |
+| Dynamic foraging | `behavior`, `behavior-videos`, `fib` | [github](https://github.com/AllenNeuralDynamics/aind-fiber-photometry-pipeline), [code ocean](https://codeocean.allenneuraldynamics.org/capsule/5712553/tree) |


### PR DESCRIPTION
Fixes the incorrect Dynamic Foraging pipeline link on the Process Data page.

Closes #130 

<!-- readthedocs-preview scicomp-docs start -->
----
📚 Documentation preview 📚: https://scicomp-docs--131.org.readthedocs.build/en/131/

<!-- readthedocs-preview scicomp-docs end -->